### PR TITLE
얼루가게 마이페이지 API를 수정한다 #47

### DIFF
--- a/src/app/[storeId]/mypage/position/page.tsx
+++ b/src/app/[storeId]/mypage/position/page.tsx
@@ -1,5 +1,7 @@
+import { getPositions } from '@/features/mypage/api/getPositions'
 import PositionWidget from '@/widgets/mypage/ui/PositionWidget'
 
 export default async function PositionPage({ params }: { params: { storeId: string } }) {
-  return <PositionWidget storeId={params.storeId} />
+  const data = await getPositions(params.storeId)
+  return <PositionWidget storeId={params.storeId} initialData={data} />
 }

--- a/src/features/mypage/api/getPositions.ts
+++ b/src/features/mypage/api/getPositions.ts
@@ -1,8 +1,8 @@
-import { axiosInstance } from '@/shared'
+import { axiosServerInstance } from '@/shared'
 import { PositionItem } from '@/shared/types/myPageTypes'
 
 async function getPositions(storeId: string): Promise<PositionItem[]> {
-  const { data } = await axiosInstance.get(`v1/stores/${storeId}/relations/members`)
+  const { data } = await axiosServerInstance.get(`v1/stores/${storeId}/relations/members`)
   return data
 }
 

--- a/src/features/mypage/api/putPosition.ts
+++ b/src/features/mypage/api/putPosition.ts
@@ -2,7 +2,7 @@ import { axiosInstance } from '@/shared'
 
 async function putPosition(storeId: string, memberId: string, position: string) {
   return axiosInstance.put(`/v1/stores/${storeId}/relations/${memberId}`, {
-    role: 'OWNER',
+    role: 'STAFF',
     position,
   })
 }

--- a/src/shared/ui/ToastMessage.tsx
+++ b/src/shared/ui/ToastMessage.tsx
@@ -38,7 +38,7 @@ export default function ToastMessage({ message, icon, open, setOpen }: ToastMess
       initial={{ y: 0, opacity: 0 }}
       animate={open ? { y: 0, opacity: 1 } : { y: 50, opacity: 0 }}
       transition={{ duration: 0.4 }}
-      className={`flex flex-row px-spacing-05 py-spacing-03 bg-layer-inverse rounded-full w-full transition-opacity justify-between absolute bottom-[100px] z-[${ZINDEX.TOAST_MESSAGE}]`}
+      className={`flex flex-row px-spacing-05 py-spacing-03 bg-layer-inverse rounded-full w-[90%] transition-opacity transjustify-between absolute bottom-[100px] z-[${ZINDEX.TOAST_MESSAGE}]`}
     >
       <div className="flex flex-row items-center">
         {icon === 'check' && (

--- a/src/widgets/inquire/ui/ByPhoneWidget.tsx
+++ b/src/widgets/inquire/ui/ByPhoneWidget.tsx
@@ -32,7 +32,6 @@ export default function ByPhoneWidget({ storeId }: { storeId: string }) {
       </div>
 
       <div className="px-4 pt-12">
-        <div></div>
         <TextField
           value={phoneNumber}
           label="고객센터 번호"

--- a/src/widgets/inquire/ui/ByPhoneWidget.tsx
+++ b/src/widgets/inquire/ui/ByPhoneWidget.tsx
@@ -32,12 +32,14 @@ export default function ByPhoneWidget({ storeId }: { storeId: string }) {
       </div>
 
       <div className="px-4 pt-12">
+        <div></div>
         <TextField
           value={phoneNumber}
           label="고객센터 번호"
           onChange={() => {}}
           size="L"
           style="outlined"
+          state="readOnly"
         />
       </div>
 

--- a/src/widgets/inquire/ui/InquireWidget.tsx
+++ b/src/widgets/inquire/ui/InquireWidget.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { TopBar, ButtonMobile } from '@eolluga/eolluga-ui'
+import { TopBar, ButtonMobile, Icon } from '@eolluga/eolluga-ui'
 
 export default function InquireWidget({ storeId }: { storeId: string }) {
   const { push } = useRouter()
@@ -24,14 +24,12 @@ export default function InquireWidget({ storeId }: { storeId: string }) {
       </div>
 
       <footer className="w-full py-3 px-4 fixed bottom-4 flex flex-col gap-4">
-        <ButtonMobile
-          size="L"
-          style="secondary"
-          type="icon-left"
-          state="enabled"
-          text1="카카오톡으로 문의하기"
-          iconKey="kakaotalk_login"
-        />
+        <button className="w-full h-[64px] py-spacing-05 px-spacing-07 gap-spacing-04 flex justify-center items-center bg-[#FEE500] text-text-on-color rounded-radius-04 shrink-0">
+          <span className="left-icon">
+            <Icon icon="kakaotalk_login" className="fill-text-on-color" />
+          </span>
+          <span className="text-black shrink-0">카카오톡으로 문의하기</span>
+        </button>
         <ButtonMobile
           size="L"
           style="border"

--- a/src/widgets/inquire/ui/InquireWidget.tsx
+++ b/src/widgets/inquire/ui/InquireWidget.tsx
@@ -24,7 +24,10 @@ export default function InquireWidget({ storeId }: { storeId: string }) {
       </div>
 
       <footer className="w-full py-3 px-4 fixed bottom-4 flex flex-col gap-4">
-        <button className="w-full h-[64px] py-spacing-05 px-spacing-07 gap-spacing-04 flex justify-center items-center bg-[#FEE500] text-text-on-color rounded-radius-04 shrink-0">
+        <button
+          type="button"
+          className="w-full h-[64px] py-spacing-05 px-spacing-07 gap-spacing-04 flex justify-center items-center bg-[#FEE500] text-text-on-color rounded-radius-04 shrink-0"
+        >
           <span className="left-icon">
             <Icon icon="kakaotalk_login" className="fill-text-on-color" />
           </span>

--- a/src/widgets/mypage/ui/PositionWidget.tsx
+++ b/src/widgets/mypage/ui/PositionWidget.tsx
@@ -10,10 +10,16 @@ import BottomSheet from '@/features/mypage/ui/BottomSheet'
 import { useGetPosition } from '@/features/mypage/model/useGetPositions'
 import { usePutPosition } from '@/features/mypage/model/usePutPosition'
 
-export default function PositionWidget({ storeId }: { storeId: string }) {
+export default function PositionWidget({
+  storeId,
+  initialData,
+}: {
+  storeId: string
+  initialData: PositionItem[]
+}) {
   const { push } = useRouter()
   const [isOpen, setIsOpen] = useState(false)
-  const { data, error } = useGetPosition(storeId)
+  const { data = initialData, error } = useGetPosition(storeId)
   const putPosition = usePutPosition()
 
   if (error) console.log(error)
@@ -70,7 +76,7 @@ export default function PositionWidget({ storeId }: { storeId: string }) {
         const [movedItem] = sourceGroup.items.splice(source.index, 1)
         destinationGroup.items.splice(destination.index, 0, movedItem)
         if (source.droppableId !== destination.droppableId) {
-          movedItem.memberId = destination.droppableId
+          movedItem.position = destination.droppableId
           putPosition.mutate({
             storeId,
             memberId: movedItem.memberId,

--- a/src/widgets/setting/api/postNotification.ts
+++ b/src/widgets/setting/api/postNotification.ts
@@ -1,0 +1,14 @@
+import { axiosInstance } from '@/shared'
+
+export interface NotificationPayload {
+  title: string
+  content: string
+  type: string
+  secretKey: string
+}
+
+async function postNotification(storeId: string, body: NotificationPayload) {
+  return axiosInstance.post(`/v1/stores/${storeId}/send-notification`, body)
+}
+
+export { postNotification }

--- a/src/widgets/setting/model/useDeleteUser.ts
+++ b/src/widgets/setting/model/useDeleteUser.ts
@@ -3,12 +3,12 @@ import { useRouter } from 'next/navigation'
 import { deleteUser } from '../api/deleteUser'
 
 function useDeleteUser() {
-  const { push } = useRouter()
+  const { replace } = useRouter()
   const { mutate } = useMutation({
     mutationKey: ['deleteUser'],
     mutationFn: () => deleteUser(),
     onSuccess: () => {
-      push('/')
+      replace('/')
     },
   })
   return { mutate }

--- a/src/widgets/setting/model/usePostNotification.ts
+++ b/src/widgets/setting/model/usePostNotification.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query'
+import { useParams } from 'next/navigation'
+import { postNotification } from '../api/postNotification'
+import { NotificationPayload } from '../api/postNotification'
+
+function usePostNotification() {
+  const { storeId }: { storeId: string } = useParams()
+  const { mutate, status } = useMutation({
+    mutationKey: ['postNotification', storeId],
+    mutationFn: (body: NotificationPayload) => postNotification(storeId, body),
+  })
+  return { mutate, status }
+}
+
+export { usePostNotification }

--- a/src/widgets/setting/model/usePostNotification.ts
+++ b/src/widgets/setting/model/usePostNotification.ts
@@ -1,7 +1,6 @@
 import { useMutation } from '@tanstack/react-query'
 import { useParams } from 'next/navigation'
-import { postNotification } from '../api/postNotification'
-import { NotificationPayload } from '../api/postNotification'
+import { postNotification, NotificationPayload } from '../api/postNotification'
 
 function usePostNotification() {
   const { storeId }: { storeId: string } = useParams()

--- a/src/widgets/setting/ui/AlarmWidget.tsx
+++ b/src/widgets/setting/ui/AlarmWidget.tsx
@@ -1,11 +1,36 @@
 'use client'
 
 import { useParams, useRouter } from 'next/navigation'
+import { useState } from 'react'
 import { TopBar, Switch } from '@eolluga/eolluga-ui'
+import { usePostNotification } from '../model/usePostNotification'
 
 export default function AlarmWidget() {
   const { push } = useRouter()
   const { storeId } = useParams()
+  const [isActive, setIsActive] = useState(false)
+  const postNotification = usePostNotification()
+
+  const handleSwitchChange = () => {
+    setIsActive(prevState => !prevState)
+    if (!isActive && process.env.SECRET_KEY) {
+      postNotification.mutate({
+        title: '푸시 알림',
+        content: '신규 직원 합류 알림이 활성화되었습니다.',
+        type: 'ALL',
+        secretKey: process.env.SECRET_KEY,
+      })
+    } else if (process.env.SECRET_KEY) {
+      postNotification.mutate({
+        title: '푸시 알림',
+        content: '신규 직원 합류 알림이 비활성화되었습니다.',
+        type: 'ALL',
+        secretKey: process.env.SECRET_KEY,
+      })
+    } else {
+      console.log('시크릿 키가 존재하지 않습니다')
+    }
+  }
 
   return (
     <div className="pt-4">

--- a/src/widgets/setting/ui/AlarmWidget.tsx
+++ b/src/widgets/setting/ui/AlarmWidget.tsx
@@ -1,36 +1,11 @@
 'use client'
 
 import { useParams, useRouter } from 'next/navigation'
-import { useState } from 'react'
 import { TopBar, Switch } from '@eolluga/eolluga-ui'
-import { usePostNotification } from '../model/usePostNotification'
 
 export default function AlarmWidget() {
   const { push } = useRouter()
   const { storeId } = useParams()
-  const [isActive, setIsActive] = useState(false)
-  const postNotification = usePostNotification()
-
-  const handleSwitchChange = () => {
-    setIsActive(prevState => !prevState)
-    if (!isActive && process.env.SECRET_KEY) {
-      postNotification.mutate({
-        title: '푸시 알림',
-        content: '신규 직원 합류 알림이 활성화되었습니다.',
-        type: 'ALL',
-        secretKey: process.env.SECRET_KEY,
-      })
-    } else if (process.env.SECRET_KEY) {
-      postNotification.mutate({
-        title: '푸시 알림',
-        content: '신규 직원 합류 알림이 비활성화되었습니다.',
-        type: 'ALL',
-        secretKey: process.env.SECRET_KEY,
-      })
-    } else {
-      console.log('시크릿 키가 존재하지 않습니다')
-    }
-  }
 
   return (
     <div className="pt-4">


### PR DESCRIPTION
-[] #47 
연결되지 않은 나머지 api들을 연결해주세요 -> 푸시알림은 컨트롤하는 Switch 컴포넌트를 기연님이 수정해주시면 반영할려고합니다.
문의하기 페이지) 카카오톡 문의하기 버튼 색을 넣었습니다
문의하기 페이지) 토스트메시지가 잘리는 오류 -> w-90퍼센트로 반영해놓았습니다
문의하기 페이지) 고객센터 번호창을 눌렀을 때 커서가 생기지 않도록 state를 readOnly로 수정했습니다
탈퇴) Replace로 수정했습니다
get 데이터들은 prefetch 가능하게 수정해주세요 -> serverInstance쓰도록 수정했습니다