### PR TITLE
FIX : 얼루가게 홈 화면에 API를 수정

### DIFF
--- a/src/entities/store/model/useGetStoreInfo.ts
+++ b/src/entities/store/model/useGetStoreInfo.ts
@@ -1,11 +1,20 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { getStoreInfo } from '../api/getStoreInfo'
 
 export function useGetStoreInfo(storeId: string) {
+  const queryClient = useQueryClient()
+
   const { data } = useQuery({
     queryKey: ['getStoreInfo', storeId],
     queryFn: () => getStoreInfo(storeId),
   })
 
-  return { data }
+  const prefetchStoreInfo = () => {
+    queryClient.prefetchQuery({
+      queryKey: ['getStoreInfo', storeId],
+      queryFn: () => getStoreInfo(storeId),
+    })
+  }
+
+  return { data, prefetchStoreInfo }
 }

--- a/src/widgets/home/model/useGetOrder.ts
+++ b/src/widgets/home/model/useGetOrder.ts
@@ -3,7 +3,7 @@ import { getOrder } from '../api/getOrder'
 
 function useGetOrder(storeId: string) {
   const { data } = useQuery({
-    queryKey: ['getOrder'],
+    queryKey: ['getOrder', storeId],
     queryFn: () => getOrder(storeId),
   })
 

--- a/src/widgets/home/model/useGetTodyDuty.ts
+++ b/src/widgets/home/model/useGetTodyDuty.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
 import { getTodayDuty } from '../api/getTodayDuty'
 
-function useGetTodayDuty(stordId: string, date: string) {
+function useGetTodayDuty(storeId: string, date: string) {
   const { data } = useQuery({
-    queryKey: ['getTodayDuty'],
-    queryFn: () => getTodayDuty(stordId, date),
+    queryKey: ['getTodayDuty', storeId, date],
+    queryFn: () => getTodayDuty(storeId, date),
   })
 
   return { data }

--- a/src/widgets/home/model/usePostOrder.ts
+++ b/src/widgets/home/model/usePostOrder.ts
@@ -1,10 +1,15 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { postOrder, GetOrderT } from '../api/postOrder'
 
 function usePostOrder(order: GetOrderT, storeId: string) {
+  const queryClient = useQueryClient()
+
   const { mutate } = useMutation({
-    mutationKey: ['postOrder'],
+    mutationKey: ['postOrder', storeId, order],
     mutationFn: () => postOrder(order, storeId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['getOrder', storeId] })
+    },
   })
 
   return { mutate }

--- a/src/widgets/home/model/usePutStoreDetail.ts
+++ b/src/widgets/home/model/usePutStoreDetail.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { StoreInfoT } from '@/entities'
 import { storeNameAtom } from '@/shared/atoms/globalAtom'
 import { useAtom } from 'jotai'
@@ -6,6 +6,7 @@ import { putStoreDetail } from '../api/putStoreDetail'
 
 function usePutStoreDetail(notice: string, storeId: string) {
   const [storeName] = useAtom(storeNameAtom)
+  const queryClient = useQueryClient()
 
   const storeInfo: StoreInfoT = {
     name: storeName,
@@ -20,8 +21,11 @@ function usePutStoreDetail(notice: string, storeId: string) {
   }
 
   const { mutate } = useMutation({
-    mutationKey: ['putStoreDetail'],
+    mutationKey: ['putStoreDetail', storeId],
     mutationFn: () => putStoreDetail(storeInfo, storeId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['getStoreInfo', storeId] })
+    },
   })
 
   return { mutate }

--- a/src/widgets/home/ui/Header.tsx
+++ b/src/widgets/home/ui/Header.tsx
@@ -1,11 +1,13 @@
 interface HeaderProps {
   title: string
+  storeCode: string
 }
 
-export default function Header({ title }: HeaderProps) {
+export default function Header({ title, storeCode }: HeaderProps) {
   return (
-    <div className="w-full fixed top-0 bg-black text-white body-03-bold-compact pt-6 pl-4 pb-4">
-      {title}
+    <div className="w-full fixed top-0 bg-black text-white pt-6 pl-4 pb-4 flex gap-2">
+      <div className="body-03-bold-compact">{title}</div>
+      <div className="body-03-regular-compact">({storeCode})</div>
     </div>
   )
 }

--- a/src/widgets/home/ui/HomeWidget.tsx
+++ b/src/widgets/home/ui/HomeWidget.tsx
@@ -10,6 +10,8 @@ import { formatCurrentDate } from '@/features'
 import { useAtom } from 'jotai'
 import { isOwnerAtom } from '@/shared'
 import { useGetStoreInfo } from '@/entities'
+import { useEffect } from 'react'
+import { storeNameAtom } from '@/shared/atoms/globalAtom'
 import { useGetOrder } from '../model/useGetOrder'
 import { useGetTodayDuty } from '../model/useGetTodyDuty'
 import { noticeAtom } from '../atoms/homeAtoms'
@@ -20,19 +22,28 @@ interface HomeWidgetProps {
 
 export default function HomeWidget({ storeId }: HomeWidgetProps) {
   const [isOwner] = useAtom(isOwnerAtom)
-  const [notice] = useAtom(noticeAtom)
+  const [, setNotice] = useAtom(noticeAtom)
+  const [, setStoreName] = useAtom(storeNameAtom)
 
   const { data: orderList } = useGetOrder(storeId)
   const { data: workList } = useGetTodayDuty(storeId, formatCurrentDate())
-  const { data: storeInfo } = useGetStoreInfo(storeId)
+  const { data: storeInfo, prefetchStoreInfo } = useGetStoreInfo(storeId)
+
+  useEffect(() => {
+    prefetchStoreInfo()
+    if (storeInfo) {
+      setStoreName(storeInfo.name)
+      setNotice(storeInfo.internalNotice)
+    }
+  }, [storeInfo, prefetchStoreInfo])
 
   return (
     <>
-      <Header title={storeInfo?.name || ''} />
+      <Header title={storeInfo?.name || ''} storeCode={storeId.slice(0, 4)} />
       <div className="mt-[76px]">
-        {isOwner && <AddPhotoButton storeId={storeId} />}
+        {isOwner ? <AddPhotoButton storeId={storeId} /> : null}
         <FlexBox direction="col" className="gap-8 mx-4">
-          <HomeNotice storeId={storeId} notice={notice || ''} />
+          <HomeNotice storeId={storeId} notice={storeInfo?.internalNotice || ''} />
           <TodayWork workList={workList?.histories || []} />
           <OrderList storeId={storeId} orderList={orderList || []} />
         </FlexBox>


### PR DESCRIPTION
## #️연관된 이슈

> #45

## 작업 내용

> querykey, mutationkey를 적절하게 수정해주세요 -> o
> 홈화면 상단에 storeId 4자리를 띄워주세요 -> storeId 앞 4자리로 설정하였는데 아닐 시 바로 수정하겠습니다.
> mutation 이후에 결과값이 바뀌는 get api들은 invalidatequeries 설정해주세요 -> 발주리스트 (order), 공지사항 (notice) api 수정하였습니다. 
> /api/v1/stores/storeid (가게 정보 조회) get api는 prefetch로 변경해주세요. -> o
> 직원인 경우 가게 사진 수정 widget이 홈화면에 뜨지 않게 해주세요 -> o