### PR TITLE
FIX: 얼루가게 회원가입 플로우에 API를 수정한다

### DIFF
--- a/src/widgets/join/model/useGetStoreInfoPrefix.ts
+++ b/src/widgets/join/model/useGetStoreInfoPrefix.ts
@@ -7,7 +7,7 @@ function useGetStoreInfoPrefix(stordIdPrefix: string) {
   const [, setStoreName] = useAtom(storeNameAtom)
   const [, setIsValidCode] = useAtom(isValidCodeAtom)
   const { mutate } = useMutation({
-    mutationKey: ['getStoreInfoPrefix'],
+    mutationKey: ['getStoreInfoPrefix', stordIdPrefix],
     mutationFn: () => getStoreInfoPrefix(stordIdPrefix),
     onSuccess: res => {
       setIsValidCode(true)

--- a/src/widgets/join/ui/SingupStore.tsx
+++ b/src/widgets/join/ui/SingupStore.tsx
@@ -73,7 +73,9 @@ export default function SingupStore({
   }
 
   const handleOpenBottomSheet = () => {
-    postStoreInfoMutate(undefined, { onSuccess: res => setStoreId(res.id) })
+    if (!storeId) {
+      postStoreInfoMutate(undefined, { onSuccess: res => setStoreId(res.id) })
+    }
     setOpenBottomSheet(true)
   }
 

--- a/src/widgets/join/ui/SingupStore.tsx
+++ b/src/widgets/join/ui/SingupStore.tsx
@@ -46,7 +46,7 @@ export default function SingupStore({
   const [storeName] = useAtom(storeNameAtom)
   const [isValidCode] = useAtom(isValidCodeAtom)
 
-  const { mutate: postStoreInfoMutate } = usePostStoreInfo(name)
+  const { mutate: postStoreInfoMutate } = usePostStoreInfo(storeName)
   const { mutate: getStoreInfoPrefixMutate } = useGetStoreInfoPrefix(store)
 
   const handleOpenDialog = () => {


### PR DESCRIPTION
## #️44



## 작업 내용

> - mutation key 수정
> - 바텀시트 새로운 가게코드 발급되지 않도록 수정
> - usePostStoreInfo name 항목을 가게 이름으로 수정

## 💬리뷰 요구사항(선택)

> - 로그인 기능과 직원 가게코드 승인 부분은 아직 진행중입니다
