### PR TITLE
REFACTOR: 로그인 플로우 개선

### DIFF
--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -45,6 +45,9 @@ export default function JoinPage() {
   const handleStoreChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setStore(e.target.value)
   }
+  const hadleStoreIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setStoreId(e.target.value)
+  }
 
   return (
     <FlexBox
@@ -71,6 +74,7 @@ export default function JoinPage() {
           setStoreId={setStoreId}
           handleNameChange={handleNameChange}
           handleStoreChange={handleStoreChange}
+          hadleStoreIdChange={hadleStoreIdChange}
           handleNextStep={handleNextStep}
           handlePreviousStep={handlePreviousStep}
         />

--- a/src/widgets/join/api/getAccountInfo.ts
+++ b/src/widgets/join/api/getAccountInfo.ts
@@ -1,0 +1,8 @@
+import { axiosInstance } from '@/shared'
+
+async function getAccountInfo() {
+  const { data } = await axiosInstance.get(`/v1/my`)
+  return data
+}
+
+export { getAccountInfo }

--- a/src/widgets/join/api/store.ts
+++ b/src/widgets/join/api/store.ts
@@ -1,0 +1,14 @@
+interface StoreT {
+  storeId: string
+  name: string
+  introduction: string
+  image: string
+  phone: string
+  address: string
+  openingHour: string
+  originalInfo: string
+  externalNotice: string
+  internalNotice: string
+}
+
+export type { StoreT }

--- a/src/widgets/join/model/useGetAccountInfo.ts
+++ b/src/widgets/join/model/useGetAccountInfo.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { useAtom } from 'jotai'
+import { isValidCodeAtom, storeNameAtom } from '@/shared/atoms/globalAtom'
+import { getStoreInfoPrefix } from '../api/getStoreInfoPrefix'
+import { getAccountInfo } from '../api/getAccountInfo'
+import { getTokenFromCookie } from '@/shared'
+
+function useGetAccountInfo() {
+  const { data } = useQuery({
+    queryKey: ['getAccountInfo'],
+    queryFn: () => getAccountInfo(),
+    enabled: getTokenFromCookie() !== null,
+  })
+
+  return { data }
+}
+
+export { useGetAccountInfo }

--- a/src/widgets/join/model/usePostLogin.ts
+++ b/src/widgets/join/model/usePostLogin.ts
@@ -1,13 +1,31 @@
 import { useMutation } from '@tanstack/react-query'
+import axios from 'axios'
 import { setTokenFromCookie } from '@/shared'
 import { postLogin } from '../api/postLogin'
 import { UserInfoT } from '../api/user'
+import { StoreT } from '../api/store'
 
-function usePostLogin(userInfo: UserInfoT) {
+function usePostLogin(userInfo: UserInfoT, handleStoreListCheck: (storelist: StoreT[]) => void) {
   const { mutate } = useMutation({
     mutationKey: ['postLogin'],
     mutationFn: () => postLogin(userInfo),
-    onSuccess: res => setTokenFromCookie(res.token, 7),
+    onSuccess: async res => {
+      setTokenFromCookie(res.token, 7)
+
+      try {
+        const response = await axios.get('/api/v1/my', {
+          headers: {
+            Authorization: `Bearer ${res.token}`,
+          },
+        })
+
+        const { storeList } = response.data
+
+        handleStoreListCheck(storeList)
+      } catch (error) {
+        console.error('Failed to fetch storelist:', error)
+      }
+    },
   })
 
   return { mutate }

--- a/src/widgets/join/model/usePostLogin.ts
+++ b/src/widgets/join/model/usePostLogin.ts
@@ -1,31 +1,16 @@
 import { useMutation } from '@tanstack/react-query'
 import axios from 'axios'
-import { setTokenFromCookie } from '@/shared'
+import { axiosInstance, setTokenFromCookie } from '@/shared'
 import { postLogin } from '../api/postLogin'
 import { UserInfoT } from '../api/user'
 import { StoreT } from '../api/store'
+import { useGetAccountInfo } from './useGetAccountInfo'
 
-function usePostLogin(userInfo: UserInfoT, handleStoreListCheck: (storelist: StoreT[]) => void) {
+function usePostLogin(userInfo: UserInfoT) {
   const { mutate } = useMutation({
     mutationKey: ['postLogin'],
     mutationFn: () => postLogin(userInfo),
-    onSuccess: async res => {
-      setTokenFromCookie(res.token, 7)
-
-      try {
-        const response = await axios.get('/api/v1/my', {
-          headers: {
-            Authorization: `Bearer ${res.token}`,
-          },
-        })
-
-        const { storeList } = response.data
-
-        handleStoreListCheck(storeList)
-      } catch (error) {
-        console.error('Failed to fetch storelist:', error)
-      }
-    },
+    onSuccess: res => setTokenFromCookie(res.token, 7),
   })
 
   return { mutate }

--- a/src/widgets/join/ui/SignupName.tsx
+++ b/src/widgets/join/ui/SignupName.tsx
@@ -3,7 +3,9 @@
 import FlexBox from '@/shared/ui/Flexbox'
 import { ButtonMobile, TextField, TopBar } from '@eolluga/eolluga-ui'
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { usePostLogin } from '../model/usePostLogin'
+import { StoreT } from '../api/store'
 
 interface SignupNameProps {
   name: string
@@ -23,8 +25,17 @@ export default function SignupName({
   handlePreviousStep,
 }: SignupNameProps) {
   const [isNumber, setIsNumber] = useState(true)
+  const router = useRouter() // 리다이렉트에 사용할 router
 
-  const { mutate } = usePostLogin({ name, phone })
+  const handleStoreListCheck = (storelist: StoreT[]) => {
+    if (storelist && storelist.length > 0) {
+      router.push(`/${storelist[0].storeId}/home`)
+    } else {
+      handleNextStep()
+    }
+  }
+
+  const { mutate } = usePostLogin({ name, phone }, handleStoreListCheck)
 
   const handleStartClick = () => {
     const phoneNumberPattern = /^[0-9]+$/
@@ -33,9 +44,9 @@ export default function SignupName({
     } else {
       setIsNumber(true)
       mutate()
-      handleNextStep()
     }
   }
+
   return (
     <>
       <TopBar

--- a/src/widgets/join/ui/SignupName.tsx
+++ b/src/widgets/join/ui/SignupName.tsx
@@ -2,10 +2,11 @@
 
 import FlexBox from '@/shared/ui/Flexbox'
 import { ButtonMobile, TextField, TopBar } from '@eolluga/eolluga-ui'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { usePostLogin } from '../model/usePostLogin'
 import { StoreT } from '../api/store'
+import { useGetAccountInfo } from '../model/useGetAccountInfo'
 
 interface SignupNameProps {
   name: string
@@ -34,8 +35,8 @@ export default function SignupName({
       handleNextStep()
     }
   }
-
-  const { mutate } = usePostLogin({ name, phone }, handleStoreListCheck)
+  const { data: accountInfo } = useGetAccountInfo()
+  const { mutate } = usePostLogin({ name, phone })
 
   const handleStartClick = () => {
     const phoneNumberPattern = /^[0-9]+$/
@@ -46,6 +47,10 @@ export default function SignupName({
       mutate()
     }
   }
+
+  useEffect(() => {
+    if (accountInfo) handleStoreListCheck(accountInfo.storeList)
+  }, [accountInfo])
 
   return (
     <>

--- a/src/widgets/join/ui/SignupName.tsx
+++ b/src/widgets/join/ui/SignupName.tsx
@@ -25,7 +25,7 @@ export default function SignupName({
   handlePreviousStep,
 }: SignupNameProps) {
   const [isNumber, setIsNumber] = useState(true)
-  const router = useRouter() // 리다이렉트에 사용할 router
+  const router = useRouter()
 
   const handleStoreListCheck = (storelist: StoreT[]) => {
     if (storelist && storelist.length > 0) {

--- a/src/widgets/join/ui/SingupStore.tsx
+++ b/src/widgets/join/ui/SingupStore.tsx
@@ -21,6 +21,7 @@ interface SignupStoreProps {
   setStoreId: React.Dispatch<React.SetStateAction<string>>
   handleNameChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   handleStoreChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  hadleStoreIdChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   handleNextStep: () => void
   handlePreviousStep: () => void
 }
@@ -31,6 +32,7 @@ export default function SingupStore({
   storeId,
   handleNameChange,
   handleStoreChange,
+  hadleStoreIdChange,
   handleNextStep,
   handlePreviousStep,
   setStore,
@@ -47,7 +49,7 @@ export default function SingupStore({
   const [isValidCode] = useAtom(isValidCodeAtom)
 
   const { mutate: postStoreInfoMutate } = usePostStoreInfo(storeName)
-  const { mutate: getStoreInfoPrefixMutate } = useGetStoreInfoPrefix(store)
+  const { mutate: getStoreInfoPrefixMutate } = useGetStoreInfoPrefix(storeId.slice(0, 4))
 
   const handleOpenDialog = () => {
     setIsLoading(true)
@@ -61,7 +63,6 @@ export default function SingupStore({
         setStoreId(res.storeId)
       },
       onError: () => {
-        setShowToast(true)
         setIsLoading(false)
         setApprovalFailed(true)
       },
@@ -82,7 +83,6 @@ export default function SingupStore({
   const handleDisagree = () => {
     setShowToast(true)
     setOpenDialog(false)
-    setApprovalFailed(true)
   }
 
   const handleAgree = () => {
@@ -119,12 +119,12 @@ export default function SingupStore({
       </div>
       <FlexBox direction="col" className="w-full px-spacing-04 gap-spacing-08">
         <TextField
-          onChange={handleStoreChange}
+          onChange={isOwner ? handleStoreChange : hadleStoreIdChange}
           size="L"
           style="underlined"
           label={isOwner ? '가게 이름' : '근무 중인 가게 코드'}
           placeholder={isOwner ? '가게 이름을 입력해주세요' : '가게 코드를 입력해주세요'}
-          value={store}
+          value={isOwner ? store : storeId.slice(0, 4)}
           state={approvalFailed ? 'error' : 'enable'}
           description={approvalFailed ? '가게 코드를 확인해주세요' : ''}
         />
@@ -148,7 +148,7 @@ export default function SingupStore({
               />
             </div>
           )}
-          {store.length > 0 && (
+          {(store.length > 0 || storeId.length > 0) && (
             <ButtonMobile
               size="L"
               style="primary"


### PR DESCRIPTION
## #️연관된 이슈

#56 

## 작업 내용

- `usePostLogin - onSuccess`를 token만 저장하도록 변경했습니다.
- `/api/v1/my` get api를 호출하는 `useGetAccountInfo` hook을 만들었고, 쿠키에 `accessToken`이 저장된 후부터 api가 호출될 수 있게끔 enable 항목을 설정했습니다.
- `SignUpName` 컴포넌트에서 `useGetAccountInfo`로 받아온 `accountInfo.storeList`가 유효한 데이터를 가진다면 `handleStoreListCheck` 함수를 호출해서 회원가입/로그인 여부를 결정짓게 했습니다

## 비고
- 내용 자체는 예림님이 짜신 코드랑 크게 다르지 않은데요! postLogin api가 호출된 후에 `onSuccess`에서 바로 get my 해오는 부분을 따로 훅으로 분리해서 사용해보았습니다. enable 속성을 활용해보시면 좋지 않을까 싶어서 제안해봅니다
- 그러나 회원가입 화면들이 `/join`이라는 하나의 페이지에 있기 때문에, `useEffect`로 `accountInfo` 변경 여부에 따라 `handleStoreListCheck`를 조작하는 것이 조금 우려가 되긴 합니다 ..!! 제가 코드를 전부 읽어본 것은 아니지만, 회원가입 플로우를 진행하다가 accountInfo 값이 변경된다면 의도치 않게 `handleStoreListCheck` 가 호출될 수도 있다는 생각이 들었어요. 조금 더 고민해보시는 것을 추천드립니다
- 혹시나 이 PR을 그대로 사용하실 생각이라면, 제가 임시로 짠 코드라 전부 다 any 타입으로 되어 있습니다. 타입 정의해서 사용해주시면 좋을 것 같습니다